### PR TITLE
fix compression packet handling for q2repro

### DIFF
--- a/src/q2proto_proto_q2repro.c
+++ b/src/q2proto_proto_q2repro.c
@@ -1960,7 +1960,11 @@ static q2proto_error_t q2repro_server_write_spawnbaseline(q2proto_servercontext_
 static q2proto_error_t q2repro_server_write_download(q2proto_servercontext_t *context, uintptr_t io_arg,
                                                      const q2proto_svc_download_t *download)
 {
-    WRITE_CHECKED(server_write, io_arg, u8, download->compressed ? svc_r1q2_zdownload : svc_download);
+    // FIX(jackharrhy) previously this was setting the compressed command to svc_r1q2_zdownload,
+    // which was 22, and q2repro was not a fan of that command, svc_q2repro_zdownload is 35 which
+    // is in the expected range of commands, so lets write that instead
+    uint8_t cmd = download->compressed ? svc_q2repro_zdownload : svc_download;
+    WRITE_CHECKED(server_write, io_arg, u8, cmd);
     WRITE_CHECKED(server_write, io_arg, i16, download->size);
     WRITE_CHECKED(server_write, io_arg, u8, download->percent);
     if (download->size > 0) {
@@ -2691,6 +2695,12 @@ static q2proto_error_t q2repro_download_data(q2proto_server_download_state_t *st
         q2proto_error_t err = q2protoio_deflate_get_data(state->deflate_io, NULL, &compressed_data, &compressed_size);
         if (err != Q2P_ERR_SUCCESS)
             return err;
+
+        // FIX(jackharrhy) q2protoio_deflate_get_data finishes the stream,
+        // so we need to end it and mark as invalid for the next packet
+        // (which will create a new stream)
+        q2protoio_deflate_end(state->deflate_io);
+        state->deflate_io_valid = false;
 
         svc_download->compressed = true;
         svc_download->data = compressed_data;

--- a/src/q2proto_server.c
+++ b/src/q2proto_server.c
@@ -277,7 +277,9 @@ q2proto_error_t q2proto_server_write_zpacket(q2proto_servercontext_t *context, q
 
     // Don't double-compress messages...
     uint8_t message_type = *(const uint8_t *)packet_data;
-    if (message_type == svc_r1q2_zpacket)
+    // FIX(jackharrhy) use context->zpacket_cmd instead of hardcoded
+    // svc_r1q2_zpacket, which q2repro isn't a fan of
+    if (message_type == context->zpacket_cmd)
         return Q2P_ERR_ALREADY_COMPRESSED;
 
     size_t deflate_io_arg;
@@ -296,7 +298,9 @@ q2proto_error_t q2proto_server_write_zpacket(q2proto_servercontext_t *context, q
         return Q2P_ERR_ALREADY_COMPRESSED;
     }
 
-    WRITE_CHECKED(server_write, io_arg, u8, svc_r1q2_zpacket);
+    // FIX(jackharrhy) use context->zpacket_cmd instead of hardcoded
+    // svc_r1q2_zpacket, which q2repro isn't a fan of
+    WRITE_CHECKED(server_write, io_arg, u8, context->zpacket_cmd);
     WRITE_CHECKED(server_write, io_arg, u16, compressed_len);
     WRITE_CHECKED(server_write, io_arg, u16, packet_len);
     WRITE_CHECKED(server_write, io_arg, raw, compressed_data, compressed_len, NULL);


### PR DESCRIPTION
- ensure we write svc_q2repro_zdownload, rather than svc_r1q2_zdownload
- handle deflate end so the stream resumes
- ensure we use context->zpacket_cmd rather than hard-coding svc_r1q2_zpacket, which was incorrect